### PR TITLE
Allow overrides

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,14 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
-        pass = "iamcommitingcrimes";
+        country = "NA";
+        state   = "SomeStateThatDefinitelyExists";
+        city    = "SomeCityThatDefinitelyExists";
+        org     = "SomeRealOrganization";
+        orgunit = "SomeRealOrganizationalUnit";
+        fqdn    = "a.real.fqdn";
+        email   = "anemail@thatis.real";
+        pass    = "iamcommitingcrimes";
       in {
         defaultPackage = pkgs.stdenv.mkDerivation {
           name = "stlsc";
@@ -14,10 +21,18 @@
           src = ./.;
 
           buildPhase = ''
-            openssl req -x509 -newkey rsa:4096 -sha256 \
-                    -passout 'pass:${pass}'            \
-                    -keyout privkey.pem \
-                    -out    tlscert.pem < opts
+            cat <<EOF | openssl req -x509 -newkey rsa:4096 -sha256 \
+                                -passout 'pass:${pass}'            \
+                                -keyout  privkey.pem               \
+                                -out     tlscert.pem
+            ${country}
+            ${state}
+            ${city}
+            ${org}
+            ${orgunit}
+            ${fqdn}
+            ${email}
+            EOF
 
             openssl pkcs12 -export -in tlscert.pem -inkey privkey.pem \
                     -password 'pass:${pass}' \

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
         };
       in {
         defaultPackage = tlsgen pkgs metadata;
+        customCert = tlsgen pkgs;
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -6,51 +6,19 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
-        country = "NA";
-        state   = "SomeStateThatDefinitelyExists";
-        city    = "SomeCityThatDefinitelyExists";
-        org     = "SomeRealOrganization";
-        orgunit = "SomeRealOrganizationalUnit";
-        fqdn    = "a.real.fqdn";
-        email   = "anemail@thatis.real";
-        pass    = "iamcommitingcrimes";
-      in {
-        defaultPackage = pkgs.stdenv.mkDerivation {
-          name = "stlsc";
-          version = "0.1.0";
-          src = ./.;
-
-          buildPhase = ''
-            cat <<EOF | openssl req -x509 -newkey rsa:4096 -sha256 \
-                                -passout 'pass:${pass}'            \
-                                -keyout  privkey.pem               \
-                                -out     tlscert.pem
-            ${country}
-            ${state}
-            ${city}
-            ${org}
-            ${orgunit}
-            ${fqdn}
-            ${email}
-            EOF
-
-            openssl pkcs12 -export -in tlscert.pem -inkey privkey.pem \
-                    -password 'pass:${pass}' \
-                    -passin   'pass:${pass}' \
-                    -passout  'pass:${pass}' \
-                    -out tlscert.pfx
-          '';
-
-          installPhase = ''
-            mkdir $out
-            echo ${pass} > $out/pass
-            cp privkey.pem $out
-            cp tlscert.pem $out
-            cp tlscert.pfx $out
-          '';
-
-          nativeBuildInputs = [ pkgs.openssl ];
+        tlsgen = import ./tls.nix;
+        metadata = {
+          country = "NA";
+          state   = "SomeStateThatDefinitelyExists";
+          city    = "SomeCityThatDefinitelyExists";
+          org     = "SomeRealOrganization";
+          orgunit = "SomeRealOrganizationalUnit";
+          fqdn    = "a.real.fqdn";
+          email   = "anemail@thatis.real";
+          pass    = "iamcommitingcrimes";
         };
+      in {
+        defaultPackage = tlsgen pkgs metadata;
       }
     );
 }

--- a/opts
+++ b/opts
@@ -1,7 +1,0 @@
-NA
-SomeStateThatDefinitelyExists
-SomeCityThatDefinitelyExists
-SomeOrganizationThatDefinitelyExists
-SomeOrginizationalUnitThatIsReal
-a.real.fqdn
-anemail@thatis.real

--- a/tls.nix
+++ b/tls.nix
@@ -1,0 +1,36 @@
+pkgs: metadata: pkgs.stdenv.mkDerivation {
+  name = "stlsc";
+  version = "0.1.0";
+  src = ./.;
+
+  buildPhase = ''
+    cat <<EOF | openssl req -x509 -newkey rsa:4096 -sha256 \
+                        -passout 'pass:${metadata.pass}'   \
+                        -keyout  privkey.pem               \
+                        -out     tlscert.pem
+    ${metadata.country}
+    ${metadata.state}
+    ${metadata.city}
+    ${metadata.org}
+    ${metadata.orgunit}
+    ${metadata.fqdn}
+    ${metadata.email}
+    EOF
+
+    openssl pkcs12 -export -in tlscert.pem -inkey privkey.pem \
+            -password 'pass:${metadata.pass}' \
+            -passin   'pass:${metadata.pass}' \
+            -passout  'pass:${metadata.pass}' \
+            -out tlscert.pfx
+  '';
+
+  installPhase = ''
+    mkdir $out
+    echo ${metadata.pass} > $out/pass
+    cp privkey.pem $out
+    cp tlscert.pem $out
+    cp tlscert.pfx $out
+  '';
+
+  nativeBuildInputs = [ pkgs.openssl ];
+}


### PR DESCRIPTION
This exposes a customCert option to the flake (i.e., `stlsc.customCert.x86_64-linux`) which accepts a metadata record containing a country, state, city, organization, organizational unit, email, fully qualified domain name, and password. All of these can be specified at build time to generate certs with actualy applicability (i.e., apply to localhost instead of `a.real.fqdn`).

This is currently lacking documentation. 